### PR TITLE
Upload benchmark report to GitHub Pages

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -149,6 +149,7 @@ jobs:
       svg-path: bench-results/${{matrix.bench}}.svg
       report-dir: bench-results/${{matrix.bench}}-report
       report-tarball: bench-results/${{matrix.bench}}-report.tar.gz
+      branch: ${{ github.head_ref || github.ref_name }}
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -159,6 +160,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{github.event.pull_request.head.sha || github.sha}}
+    - name: Modify Branch Name
+      run: git switch -c ${{env.branch}}
     - name: Download artifacts
       id: download
       uses: actions/download-artifact@v3
@@ -225,3 +228,103 @@ jobs:
       with:
         path: ${{env.report-tarball}}
         name: ${{matrix.bench}}-report
+
+  upload-reports:
+    concurrency:
+      cancel-in-progress: false
+      group: "pages"
+    permissions: 
+      pages: write
+      id-token: write
+      contents: write
+      pull-requests: write
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+
+    name: Upload Reports
+    if: (github.head_ref || github.ref_name) != 'gh-pages'
+    needs: [build, bench]
+    runs-on: ubuntu-latest
+    env:
+      sha: ${{github.event.pull_request.head.sha || github.sha}}
+      branch: ${{ github.head_ref || github.ref_name }}
+      pages-dir: pages
+    steps:
+    - name: Checkout HEAD
+      uses: actions/checkout@v4
+      with:
+        ref: ${{env.sha}}
+    - name: Modify Branch Name
+      run: git switch -c ${{env.branch}}
+    - name: Checkout gh-pages
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+        path: ${{env.pages-dir}}
+        token: ${{secrets.GITHUB_TOKEN}}
+    - name: Download artifacts
+      id: download
+      uses: actions/download-artifact@v3
+      with:
+        path: workspace/downloads
+    - name: Extract bench results and generate
+      id: generate
+      shell: bash
+      run: |
+        set -euxo pipefail
+        DL_DIR="${{steps.download.outputs.download-path}}"
+        WORKDIR=workspace
+        tar xaf "${DL_DIR}/artifacts/artifacts.tar.zst" --directory="${WORKDIR}"
+        ARTIFACT_DIRS=${WORKDIR}/artifacts
+        REPORT_DIR=${WORKDIR}/reports
+        cat "${ARTIFACT_DIRS}/benchs.list" | while read -r BENCH; do
+          DEST=${REPORT_DIR}/${BENCH}
+          mkdir -p "${DEST}"
+          ORIG_REPORT_NAME=${BENCH}-report
+          tar xvf "${DL_DIR}/${ORIG_REPORT_NAME}/${ORIG_REPORT_NAME}.tar.gz" --directory "${DEST}" --strip-components=1
+        done
+        ls -R "${REPORT_DIR}"
+
+        ARGS=(-c "${{env.pages-dir}}/reports.json" -i "${REPORT_DIR}" -o "${{env.pages-dir}}/docs/reports")
+        ARGS+=(-R "${{github.event.repository.full_name}}")
+        PULL=${{github.event.pull_request.number}}
+        PULL_BASE_BRANCH=${{github.event.pull_request.head.ref}}
+        PULL_BASE_COMMIT=${{github.event.pull_request.head.sha}}
+        PULL_TITLE="${{github.event.pull_request.title}}"
+        if [[ -n "${PULL}" ]]; then
+          ARGS+=("--pull-number" "${PULL}")
+          ARGS+=("--pull-title" "${PULL_TITLE}")
+          ARGS+=("--pull-base-branch" "${PULL_BASE_BRANCH}")
+          ARGS+=("--pull-base-commit" "${PULL_BASE_COMMIT}")
+        fi
+
+        ls -R "${{env.pages-dir}}"
+
+        "${ARTIFACT_DIRS}/exes/bench-chart" update-report-pages "${ARGS[@]}"
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v2
+      with:
+        # Upload entire repository
+        path: ${{env.pages-dir}}/docs
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2
+    - name: Report to PR
+      if: ${{ github.event_name == 'pull_request' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        URL: ${{ github.event.pull_request.html_url }}
+      run: >
+        gh pr comment ${{github.event.pull_request.number}}
+        -b ":bar_chart: Benchmark report for ${{env.sha}} is uploaded to: ${{steps.generate.outputs.url}}"
+    - name: Make commit
+      run: |
+        cd pages
+        git config --global user.name "github-actions"
+        git config --global user.email "github-actions"
+        git add .
+        git commit -m "[bot] Report for ${{env.sha}} (${{env.branch}})"
+        git push origin gh-pages

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -200,20 +200,24 @@ jobs:
         ${{steps.benchmark.outputs.baseline-desc}}
         STOP_HERE_EOF_HERE
         )
+        PULL=${{github.event.pull_request.number}}
+        PULL_BASE_BRANCH=${{github.event.pull_request.head.ref}}
+        PULL_BASE_COMMIT=${{github.event.pull_request.head.sha}}
+        PULL_TITLE="${{github.event.pull_request.title}}"
 
-        if [[ -z "${BASELINE}" ]]; then
-          ./artifacts/exes/bench-chart \
-            -i "${{env.csv-path}}" \
-            -o "${{env.report-dir}}" --git \
-            -R "${{matrix.bench}}"
-        else
-          ./artifacts/exes/bench-chart \
-            -i "${{env.csv-path}}" \
-            -o "${{env.report-dir}}" --git \
-            -R "${{matrix.bench}}" \
-            --baseline "${BASELINE}" \
-            --baseline-desc "${BASELINE_DESC}"
+        ARGS=(--git --repo "${{github.event.repository.full_name}}")
+        ARGS+=(-i "${{env.csv-path}}" -o "${{env.report-dir}}")
+        ARGS+=(-R "${{matrix.bench}}")
+
+        if [[ -n "${BASELINE}" ]]; then
+          ARGS+=(--baseline "${BASELINE}")
+          ARGS+=(--baseline-desc "${BASELINE_DESC}")
+          ARGS+=(--pull-number "${PULL}")
+          ARGS+=(--pull-title "${PULL_TITLE}")
+          ARGS+=(--pull-base-branch "${PULL_BASE_BRANCH}")
+          ARGS+=(--pull-base-commit "${PULL_BASE_COMMIT}")
         fi
+        ./artifacts/exes/bench-chart "${ARGS[@]}"
 
     - name: Compress Report
       if: always()

--- a/app/bench-chart/Main.hs
+++ b/app/bench-chart/Main.hs
@@ -1,62 +1,25 @@
 {-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 
 module Main (main) where
 
-import Chart hiding (abs, (<.>))
-import Control.Applicative (optional, (<**>))
-import Control.DeepSeq
-import Control.Exception
-import qualified Control.Foldl as L
-import Control.Lens hiding ((<.>))
+import Control.Applicative ((<**>))
 import Data.Generics.Labels ()
-import qualified Data.Map.Strict as Map
-import Data.Maybe (fromJust, fromMaybe)
-import Data.Semigroup (Arg (..), Min (..))
-import qualified Data.Text as T
-import qualified Data.Vector as V
 import GHC.Generics (Generic)
-import GitHash
-import qualified Lucid
 import Options.Applicative ((<|>))
 import qualified Options.Applicative as Opt
 import Pages
-import Parse (Benchs, decodeBenchs)
-import Plot
 import Report
-import System.Directory
-import System.FilePath
 import System.IO
-import Types
-import UnliftIO (evaluateDeep, pooledForConcurrently)
-
-data Opts = Opts
-  { input :: !FilePath
-  , output :: !FilePath
-  , sufficesToStrip :: !(Maybe Int)
-  , reportName :: !(Maybe T.Text)
-  , gitInspect :: !Bool
-  , baseline :: !(Maybe FilePath)
-  , baselineDescr :: !(Maybe T.Text)
-  }
-  deriving (Show, Eq, Ord, Generic)
 
 main :: IO ()
 main = do
@@ -66,86 +29,8 @@ main = do
     SingleReport opts -> generateSingleReport opts
     UpdateReportPages opts -> updateReportPages opts
 
-generateSingleReport :: Opts -> IO ()
-generateSingleReport Opts {..} = do
-  !trie <-
-    evaluateDeep . pruneSuffices sufficesToStrip =<< decodeBenchs input
-  !mbases <-
-    evaluateDeep
-      . fmap (pruneSuffices sufficesToStrip)
-      =<< mapM decodeBenchs baseline
-  let colorMap = buildColorMap trie
-  createDirectoryIfMissing True output
-  let baseDesc = fromMaybe "Baseline" baselineDescr
-  svgs <- pooledForConcurrently (Map.mapWithKey (,) trie) \(k, bg) -> do
-    let mbase = (baseDesc,) <$> (Map.lookup k =<< mbases)
-    !plots <- evaluate $ mkPlots colorMap k mbase bg
-    !mWinner <-
-      evaluate
-        $ force
-        $ fromJust
-        $ ifoldMap
-          ( \i BenchCase {..} ->
-              Just
-                Winner
-                  { timeWinner = Min $ Arg mean i
-                  , allocWinner = Min $ Arg (fromMaybe 0 alloc) i
-                  , copiedWinner = Min $ Arg (fromMaybe 0 copied) i
-                  }
-          )
-          bg
-    paths <- iforM plots \crit chart -> do
-      let typeStr = case crit of
-            Time -> "time"
-            Alloc -> "alloc"
-            Copied -> "copied"
-          baseName = T.unpack (T.intercalate "-" k) </> typeStr <.> "svg"
-          outPath = output </> baseName
-      createDirectoryIfMissing True $ takeDirectory outPath
-      writeChartOptions outPath chart
-      hPutStrLn stderr $ "Written: " <> outPath
-      pure baseName
-    pure (paths, mWinner)
-
-  mGit <-
-    if gitInspect
-      then
-        either throwIO (pure . Just)
-          =<< either throwIO getGitInfo
-          =<< getGitRoot
-          =<< getCurrentDirectory
-      else pure Nothing
-  let reportHtml = output </> "index.html"
-  print
-    $ L.fold
-      ( L.premap snd
-          $ (,,)
-          <$> L.premap timeWinner winnerCountL
-          <*> L.premap allocWinner winnerCountL
-          <*> L.premap copiedWinner winnerCountL
-      )
-      svgs
-  Lucid.renderToFile reportHtml $ buildReport reportName mGit (baseDesc <$ baseline) svgs
-  hPutStrLn stderr $ "Report Written to: " <> reportHtml
-
-pruneSuffices :: Maybe Int -> Benchs -> Benchs
-pruneSuffices = maybe id \c ->
-  Map.mapKeysMonotonic
-    ( \(V.fromList -> xs) ->
-        V.toList $ V.take (max 0 (V.length xs - c)) xs
-    )
-
-buildColorMap :: (Foldable t) => t (Map.Map T.Text a) -> Map.Map T.Text Colour
-buildColorMap =
-  Map.fromList
-    . flip zip (cycle paletteR)
-    . L.fold
-      ( L.premap Map.keysSet
-          $ L.handles folded L.list
-      )
-
 data Cmd
-  = SingleReport !Opts
+  = SingleReport !SingleReportOpts
   | UpdateReportPages !PagesOpts
   deriving (Show, Eq, Ord, Generic)
 
@@ -157,95 +42,5 @@ optsP = Opt.info (p <**> Opt.helper <|> genRep) $ Opt.progDesc "Converts tasty-b
         $ Opt.command "update-report-pages"
         $ Opt.info updateP
         $ Opt.progDesc "Updates GitHub Pages reports"
-    p =
-      SingleReport <$> do
-        input <-
-          Opt.strOption
-            $ Opt.long "input"
-            <> Opt.short 'i'
-            <> Opt.metavar "FILE"
-            <> Opt.help "Input CSV file"
-        output <-
-          Opt.strOption
-            $ Opt.long "output"
-            <> Opt.short 'o'
-            <> Opt.metavar "DIR"
-            <> Opt.help "Output directory"
-        sufficesToStrip <-
-          optional
-            $ Opt.option Opt.auto
-            $ Opt.long "strip-suffices"
-            <> Opt.short 's'
-            <> Opt.metavar "NUM"
-            <> Opt.help "Number of prefix to drop."
-        reportName <-
-          optional
-            $ Opt.strOption
-            $ Opt.long "report-name"
-            <> Opt.short 'R'
-            <> Opt.metavar "TITLE"
-            <> Opt.help "Optional Report Name"
-        gitInspect <- Opt.switch $ Opt.long "git" <> Opt.help "Inspects git metadata and includes in the report"
-        baseline <-
-          Opt.optional
-            $ Opt.strOption
-            $ Opt.long "baseline"
-            <> Opt.short 'B'
-            <> Opt.metavar "FILE"
-            <> Opt.help "Optional path to the baseline CSV to compare with"
-        baselineDescr <-
-          Opt.optional
-            $ Opt.strOption
-            $ Opt.long "baseline-desc"
-            <> Opt.metavar "FILE"
-            <> Opt.help "Description for the baseline"
-        pure Opts {..}
-    updateP =
-      UpdateReportPages <$> do
-        configPath <-
-          Opt.strOption
-            $ Opt.long "config"
-            <> Opt.short 'c'
-            <> Opt.metavar "PATH"
-            <> Opt.help "The path to the reports.json"
-        input <-
-          Opt.strOption
-            $ Opt.long "input"
-            <> Opt.short 'i'
-            <> Opt.metavar "DIR"
-            <> Opt.help "The directory containing input report directories"
-        output <-
-          Opt.strOption
-            $ Opt.long "output"
-            <> Opt.short 'o'
-            <> Opt.metavar "DIR"
-            <> Opt.help "The deploy path"
-        repo <-
-          Opt.strOption
-            $ Opt.long "repo"
-            <> Opt.short 'R'
-            <> Opt.metavar "OWNER/REPO"
-            <> Opt.help "Repository full name"
-        pull <- Opt.optional do
-          pullNumber <-
-            Opt.option Opt.auto
-              $ Opt.long "pull-number"
-              <> Opt.metavar "NUM"
-              <> Opt.help "Pull Request Number"
-          pullTitle <-
-            Opt.strOption
-              $ Opt.long "pull-title"
-              <> Opt.metavar "TITLE"
-              <> Opt.help "Pull Request Title"
-          baseBranch <-
-            Opt.strOption
-              $ Opt.long "pull-base-branch"
-              <> Opt.metavar "REF_NAME"
-              <> Opt.help "Pull Request base branch"
-          baseCommit <-
-            Opt.strOption
-              $ Opt.long "pull-base-commit"
-              <> Opt.metavar "SHA"
-              <> Opt.help "Pull Request base commit"
-          pure PullRequest {..}
-        pure PagesOpts {..}
+    p = SingleReport <$> singleReportOptsP
+    updateP = UpdateReportPages <$> pagesOptsP

--- a/app/bench-chart/Main.hs
+++ b/app/bench-chart/Main.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -31,7 +35,9 @@ import qualified Data.Vector as V
 import GHC.Generics (Generic)
 import GitHash
 import qualified Lucid
+import Options.Applicative ((<|>))
 import qualified Options.Applicative as Opt
+import Pages
 import Parse (Benchs, decodeBenchs)
 import Plot
 import Report
@@ -54,12 +60,16 @@ data Opts = Opts
 
 main :: IO ()
 main = do
-  Opts {..} <- Opt.execParser optsP
   hSetBuffering stderr LineBuffering
+  cmd <- Opt.execParser optsP
+  case cmd of
+    SingleReport opts -> generateSingleReport opts
+    UpdateReportPages opts -> updateReportPages opts
+
+generateSingleReport :: Opts -> IO ()
+generateSingleReport Opts {..} = do
   !trie <-
-    evaluateDeep
-      . pruneSuffices sufficesToStrip
-      =<< decodeBenchs input
+    evaluateDeep . pruneSuffices sufficesToStrip =<< decodeBenchs input
   !mbases <-
     evaluateDeep
       . fmap (pruneSuffices sufficesToStrip)
@@ -105,7 +115,7 @@ main = do
           =<< getGitRoot
           =<< getCurrentDirectory
       else pure Nothing
-  let reportHtml = output </> "report.html"
+  let reportHtml = output </> "index.html"
   print
     $ L.fold
       ( L.premap snd
@@ -134,48 +144,108 @@ buildColorMap =
           $ L.handles folded L.list
       )
 
-optsP :: Opt.ParserInfo Opts
-optsP = Opt.info (p <**> Opt.helper) $ Opt.progDesc "Converts tasty-bench output to  bar charts, scaling per-group not global."
+data Cmd
+  = SingleReport !Opts
+  | UpdateReportPages !PagesOpts
+  deriving (Show, Eq, Ord, Generic)
+
+optsP :: Opt.ParserInfo Cmd
+optsP = Opt.info (p <**> Opt.helper <|> genRep) $ Opt.progDesc "Converts tasty-bench output to  bar charts, scaling per-group not global."
   where
-    p = do
-      input <-
-        Opt.strOption
-          $ Opt.long "input"
-          <> Opt.short 'i'
-          <> Opt.metavar "FILE"
-          <> Opt.help "Input CSV file"
-      output <-
-        Opt.strOption
-          $ Opt.long "output"
-          <> Opt.short 'o'
-          <> Opt.metavar "DIR"
-          <> Opt.help "Output directory"
-      sufficesToStrip <-
-        optional
-          $ Opt.option Opt.auto
-          $ Opt.long "strip-suffices"
-          <> Opt.short 's'
-          <> Opt.metavar "NUM"
-          <> Opt.help "Number of prefix to drop."
-      reportName <-
-        optional
-          $ Opt.strOption
-          $ Opt.long "report-name"
-          <> Opt.short 'R'
-          <> Opt.metavar "TITLE"
-          <> Opt.help "Optional Report Name"
-      gitInspect <- Opt.switch $ Opt.long "git" <> Opt.help "Inspects git metadata and includes in the report"
-      baseline <-
-        Opt.optional
-          $ Opt.strOption
-          $ Opt.long "baseline"
-          <> Opt.short 'B'
-          <> Opt.metavar "FILE"
-          <> Opt.help "Optional path to the baseline CSV to compare with"
-      baselineDescr <-
-        Opt.optional
-          $ Opt.strOption
-          $ Opt.long "baseline-desc"
-          <> Opt.metavar "FILE"
-          <> Opt.help "Description for the baseline"
-      pure Opts {..}
+    genRep =
+      Opt.hsubparser
+        $ Opt.command "update-report-pages"
+        $ Opt.info updateP
+        $ Opt.progDesc "Updates GitHub Pages reports"
+    p =
+      SingleReport <$> do
+        input <-
+          Opt.strOption
+            $ Opt.long "input"
+            <> Opt.short 'i'
+            <> Opt.metavar "FILE"
+            <> Opt.help "Input CSV file"
+        output <-
+          Opt.strOption
+            $ Opt.long "output"
+            <> Opt.short 'o'
+            <> Opt.metavar "DIR"
+            <> Opt.help "Output directory"
+        sufficesToStrip <-
+          optional
+            $ Opt.option Opt.auto
+            $ Opt.long "strip-suffices"
+            <> Opt.short 's'
+            <> Opt.metavar "NUM"
+            <> Opt.help "Number of prefix to drop."
+        reportName <-
+          optional
+            $ Opt.strOption
+            $ Opt.long "report-name"
+            <> Opt.short 'R'
+            <> Opt.metavar "TITLE"
+            <> Opt.help "Optional Report Name"
+        gitInspect <- Opt.switch $ Opt.long "git" <> Opt.help "Inspects git metadata and includes in the report"
+        baseline <-
+          Opt.optional
+            $ Opt.strOption
+            $ Opt.long "baseline"
+            <> Opt.short 'B'
+            <> Opt.metavar "FILE"
+            <> Opt.help "Optional path to the baseline CSV to compare with"
+        baselineDescr <-
+          Opt.optional
+            $ Opt.strOption
+            $ Opt.long "baseline-desc"
+            <> Opt.metavar "FILE"
+            <> Opt.help "Description for the baseline"
+        pure Opts {..}
+    updateP =
+      UpdateReportPages <$> do
+        configPath <-
+          Opt.strOption
+            $ Opt.long "config"
+            <> Opt.short 'c'
+            <> Opt.metavar "PATH"
+            <> Opt.help "The path to the reports.json"
+        input <-
+          Opt.strOption
+            $ Opt.long "input"
+            <> Opt.short 'i'
+            <> Opt.metavar "DIR"
+            <> Opt.help "The directory containing input report directories"
+        output <-
+          Opt.strOption
+            $ Opt.long "output"
+            <> Opt.short 'o'
+            <> Opt.metavar "DIR"
+            <> Opt.help "The deploy path"
+        repo <-
+          Opt.strOption
+            $ Opt.long "repo"
+            <> Opt.short 'R'
+            <> Opt.metavar "OWNER/REPO"
+            <> Opt.help "Repository full name"
+        pull <- Opt.optional do
+          pullNumber <-
+            Opt.option Opt.auto
+              $ Opt.long "pull-number"
+              <> Opt.metavar "NUM"
+              <> Opt.help "Pull Request Number"
+          pullTitle <-
+            Opt.strOption
+              $ Opt.long "pull-title"
+              <> Opt.metavar "TITLE"
+              <> Opt.help "Pull Request Title"
+          baseBranch <-
+            Opt.strOption
+              $ Opt.long "pull-base-branch"
+              <> Opt.metavar "REF_NAME"
+              <> Opt.help "Pull Request base branch"
+          baseCommit <-
+            Opt.strOption
+              $ Opt.long "pull-base-commit"
+              <> Opt.metavar "SHA"
+              <> Opt.help "Pull Request base commit"
+          pure PullRequest {..}
+        pure PagesOpts {..}

--- a/app/bench-chart/Pages.hs
+++ b/app/bench-chart/Pages.hs
@@ -1,0 +1,337 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+
+module Pages (PagesOpts (..), PullRequest (..), updateReportPages) where
+
+import Control.DeepSeq
+import Control.Lens hiding ((<.>))
+import Control.Monad (forM_, guard, when)
+import Control.Monad.Trans.Maybe (MaybeT (..))
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import qualified Data.Aeson as J
+import qualified Data.Bifunctor as Bi
+import qualified Data.Char as C
+import Data.Function (on)
+import Data.Generics.Labels ()
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HM
+import Data.Hashable (Hashable)
+import Data.List (sortOn)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes, fromJust)
+import Data.Ord (Down (..), comparing)
+import Data.String (IsString, fromString)
+import qualified Data.Text as T
+import Data.Time (FormatTime, ParseTime, ZonedTime, defaultTimeLocale, formatTime, parseTimeOrError, zonedTimeToUTC)
+import GHC.Generics (Generic)
+import GitHash
+import Lucid
+import Path
+import Path.IO
+import System.Directory
+import System.FilePath.Glob (globDir1)
+import System.IO (hPutStrLn)
+import UnliftIO.Environment (lookupEnv)
+import UnliftIO.Exception
+import UnliftIO.IO
+
+data PagesOpts = PagesOpts
+  { input :: FilePath
+  , output :: FilePath
+  , repo :: T.Text
+  , pull :: Maybe PullRequest
+  , configPath :: FilePath
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+data Dirs = Dirs {inputDir, commitOutDir :: Path Abs Dir}
+  deriving (Show, Eq, Ord, Generic)
+
+updateReportPages :: PagesOpts -> IO ()
+updateReportPages opts@PagesOpts {..} = do
+  !reps <-
+    either throwString evaluateDeep
+      =<< J.eitherDecodeFileStrict' @Reports configPath
+  ginfo <-
+    either throwIO pure
+      =<< either throwIO getGitInfo
+      =<< getGitRoot
+      =<< getCurrentDirectory
+  let newCommit =
+        Commit
+          { commit = fromString $ giHash ginfo
+          , branch = fromString $ giBranch ginfo
+          , pull
+          , commitMessage = fromString $ giCommitMessage ginfo
+          , commitDate = parseTimeOrError True defaultTimeLocale "%a %b %-d %H:%M:%S %Y %z" $ giCommitDate ginfo
+          }
+      (symlink, brs') =
+        Bi.second
+          ( take 10
+              . sortOn (Down . view #commitDate . snd)
+              . HM.toList
+          )
+          $ HM.alterF
+            ( maybe
+                (True, Just newCommit)
+                ( \c ->
+                    if commitDate c > commitDate newCommit
+                      then (False, Just c)
+                      else (True, Just newCommit)
+                )
+            )
+            (newCommit ^. #branch)
+          $ branchCommits reps
+      recentComms =
+        take 10
+          $ sortOn (Down . view #commitDate . snd)
+          $ HM.toList
+          $ HM.insert (newCommit ^. #commit) newCommit
+          $ commits reps
+  output' <- resolveDir' output
+  createDirIfMissing True output'
+  inputDir <- resolveDir' input
+  let commitOutDir =
+        output' </> treeReportRelPath (runCommitHash $ newCommit ^. #commit)
+  when symlink do
+    let brDir = output' </> treeReportRelPath (runBranchName $ newCommit ^. #branch)
+    thereSym <- doesDirExist brDir
+    when thereSym $ removeDirLink brDir
+    createDirIfMissing True $ parent brDir
+    createDirLink commitOutDir brDir
+  let rootIndexPath = fromAbsFile $ output' </> [relfile|index.html|]
+  hPutStrLn stderr $ "Writing root index.html to: " <> rootIndexPath <> " ..."
+  renderToFile rootIndexPath $ generateIndex opts brs' recentComms
+  hPutStrLn stderr $ "Root index.html Written to: " <> rootIndexPath <> " ."
+  let dirs = Dirs {..}
+  generateCommitIndex repo dirs newCommit
+  J.encodeFile
+    configPath
+    Reports
+      { branchCommits = HM.fromList brs'
+      , commits = HM.fromList recentComms
+      }
+  mout <- lookupEnv "GITHUB_OUTPUT"
+  forM_ mout $ \stepOutPath -> do
+    let (own, T.drop 1 -> rep) = T.breakOn "/" repo
+    appendFile stepOutPath
+      $ "url=https://"
+      <> T.unpack own
+      <> ".github.io/"
+      <> T.unpack rep
+      <> "/reports/"
+      <> T.unpack (runCommitHash (newCommit ^. #commit))
+      <> "/index.html"
+      <> "\n"
+
+generateCommitIndex :: T.Text -> Dirs -> Commit -> IO ()
+generateCommitIndex repo Dirs {..} Commit {..} = do
+  createDirIfMissing True commitOutDir
+  hPutStrLn stderr $ "Globbing: " <> fromAbsDir inputDir
+  reports0 <- globDir1 "*/index.html" $ fromAbsDir inputDir
+  hPutStrLn stderr $ "Globbed: " <> show reports0
+  !reports <-
+    Map.fromList
+      . catMaybes
+      <$> traverse
+        ( \fp0 -> runMaybeT do
+            fp <- parseAbsFile fp0
+            let origDir = parent fp
+            p <- doesDirExist origDir
+            guard p
+            pure (dirname origDir, origDir)
+        )
+        reports0
+  hPutStrLn stderr $ "Detected reports: " <> show reports
+  iforM_ reports $ \k fp -> do
+    hPutStrLn stderr $ "Copying dir: " <> show (k, fp)
+    copyDirRecur fp (commitOutDir </> k)
+  let reportIndex = fromAbsFile $ commitOutDir </> [relfile|index.html|]
+  hPutStrLn stderr $ "Writing commit index to: " <> reportIndex <> " ..."
+  renderToFile reportIndex
+    $ mkHtmlTitled ("Benchmark Report for " <> runCommitHash commit) do
+      h1_ $ "Herbrand benchmark report(s) for " <> toHtml commit
+      h2_ "Metadata"
+      table_ $ tbody_ do
+        tr_ $ do
+          th_ [scope_ "row"] "Commit"
+          td_ $ gitHubTreeLink repo (runCommitHash commit) commit
+        tr_ $ do
+          th_ [scope_ "row"] "Date"
+          td_ $ toHtml commitDate
+        tr_ $ do
+          th_ [scope_ "row"] "Message"
+          td_ $ toHtml commitMessage
+        tr_ do
+          th_ [scope_ "row"] "Branch"
+          td_ $ gitHubTreeLink repo (runBranchName branch) branch
+        forM_ pull \_ -> do
+          th_ [scope_ "row"] "Pull Req"
+          td_ $ formatPull repo pull
+
+      h2_ "Reports"
+      ul_ $ iforM_ reports \k _ -> li_ do
+        a_ [href_ $ T.pack $ fromRelFile $ k </> [relfile|index.html|]]
+          $ toHtml (titleCase $ fromRelDir k)
+  hPutStrLn stderr $ "Commit index written to: " <> reportIndex
+
+titleCase :: FilePath -> T.Text
+titleCase =
+  T.unwords
+    . map (_head %~ C.toUpper)
+    . filter (not . T.null)
+    . T.split (`elem` ("-_" :: String))
+    . T.dropWhileEnd (== '/')
+    . T.pack
+
+gitHubTreeLink :: (ToHtml body) => T.Text -> T.Text -> body -> Html ()
+gitHubTreeLink repo tree = a_ [href_ $ "https://github.com/" <> repo <> "/tree/" <> tree] . toHtml
+
+mkHtmlTitled :: T.Text -> Html () -> Lucid.Html ()
+mkHtmlTitled title body = doctypehtml_ do
+  head_ do
+    title_ $ toHtml title
+    meta_ [charset_ "UTF-8"]
+    meta_
+      [ name_ "viewport"
+      , content_ "width=device-width, initial-scale=1.0"
+      ]
+    link_ [rel_ "stylesheet", href_ "https://cdn.simplecss.org/simple.min.css"]
+  body
+
+treeReportRelPath :: T.Text -> Path Rel Dir
+treeReportRelPath name = fromJust $ parseRelDir (T.unpack name)
+
+linkToReportRoot :: (ToHtml body) => T.Text -> body -> Html ()
+linkToReportRoot name =
+  a_
+    [ href_
+        $ T.pack
+        $ fromRelFile
+        $ treeReportRelPath name
+        </> [relfile|index.html|]
+    ]
+    . toHtml
+
+generateIndex :: PagesOpts -> [(BranchName, Commit)] -> [(CommitHash, Commit)] -> Lucid.Html ()
+generateIndex PagesOpts {repo} branches comms = mkHtmlTitled "Herbrand Benchmark Reports" do
+  h1_ "Herbrand benchmark reports"
+
+  h2_ "Recently updated branches"
+  table_ do
+    thead_ $ tr_ do
+      th_ [scope_ "col"] "Branch"
+      th_ [scope_ "col"] "Commit"
+      th_ [scope_ "col"] "Date"
+      th_ [scope_ "col"] "Pull"
+      th_ [scope_ "col"] "Message"
+    tbody_ $ forM_ branches \(bName, Commit {..}) -> tr_ do
+      th_ [scope_ "row"]
+        $ linkToReportRoot (runBranchName bName) bName
+      td_
+        $ linkToReportRoot (runBranchName bName)
+        $ T.take 7
+        $ runCommitHash commit
+      td_ $ toHtml commitDate
+      td_ $ formatPull repo pull
+      td_ $ toHtml commitMessage
+
+  h2_ "Recent commits"
+  table_ do
+    thead_ $ tr_ do
+      th_ [scope_ "col"] "Commit"
+      th_ [scope_ "col"] "Date"
+      th_ [scope_ "col"] "Message"
+      th_ [scope_ "col"] "Branch"
+      th_ [scope_ "col"] "Pull"
+    tbody_ $ forM_ comms \(_, Commit {..}) -> tr_ do
+      th_ [scope_ "row"]
+        $ linkToReportRoot (runCommitHash commit)
+        $ T.take 7
+        $ runCommitHash commit
+      td_ $ toHtml commitDate
+      td_ $ toHtml commitMessage
+      td_ $ gitHubTreeLink repo (runBranchName branch) branch
+      td_ $ formatPull repo pull
+
+formatPull :: T.Text -> Maybe PullRequest -> Html ()
+formatPull repo p = case p of
+  Nothing -> "-"
+  Just PullRequest {..} ->
+    a_ [href_ $ "https://github.com/" <> repo <> "/pull/" <> T.pack (show pullNumber)]
+      $ "#"
+      <> toHtml (show pullNumber)
+      <> ": "
+      <> toHtml pullTitle
+
+newtype Timestamp = Timestamp {getTimestamp :: ZonedTime}
+  deriving (Show, Generic)
+  deriving newtype (ToJSON, FromJSON, ParseTime, FormatTime, NFData)
+
+instance ToHtml Timestamp where
+  toHtml = toHtml . formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S %Z"
+  toHtmlRaw = toHtmlRaw . formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S %Z"
+
+instance Eq Timestamp where
+  (==) = (==) `on` zonedTimeToUTC . getTimestamp
+
+instance Ord Timestamp where
+  compare = comparing $ zonedTimeToUTC . getTimestamp
+
+newtype BranchName = BranchName {runBranchName :: T.Text}
+  deriving (Show, Eq, Ord, Generic)
+  deriving newtype (FromJSON, ToJSON, Hashable, IsString, FromJSONKey, ToJSONKey, NFData, ToHtml)
+
+newtype CommitHash = CommitHash {runCommitHash :: T.Text}
+  deriving (Show, Eq, Ord, Generic)
+  deriving newtype (FromJSON, ToJSON, Hashable, IsString, FromJSONKey, ToJSONKey, NFData, ToHtml)
+
+data ReportInfo = ReportInfo {commit :: T.Text, branch :: T.Text}
+  deriving (Show, Eq, Ord, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data PullRequest = PullRequest
+  { pullNumber :: Word
+  , pullTitle :: T.Text
+  , baseBranch :: BranchName
+  , baseCommit :: CommitHash
+  }
+  deriving (Show, Eq, Ord, Generic)
+  deriving anyclass (FromJSON, ToJSON, NFData)
+
+data Commit = Commit
+  { commit :: CommitHash
+  , branch :: BranchName
+  , pull :: Maybe PullRequest
+  , commitMessage :: T.Text
+  , commitDate :: Timestamp
+  }
+  deriving (Show, Generic)
+  deriving anyclass (FromJSON, ToJSON, NFData)
+
+data Reports = Reports
+  { branchCommits :: HashMap BranchName Commit
+  , commits :: HashMap CommitHash Commit
+  }
+  deriving (Show, Generic)
+  deriving anyclass (FromJSON, ToJSON, NFData)

--- a/app/bench-chart/Report.hs
+++ b/app/bench-chart/Report.hs
@@ -1,15 +1,29 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 
-module Report (buildReport) where
+module Report (
+  SingleReportOpts (..),
+  singleReportOptsP,
+  generateSingleReport,
+) where
 
+import Chart hiding (abs, (<.>))
+import Control.Applicative (optional)
+import Control.DeepSeq
+import Control.Exception
 import qualified Control.Foldl as L
 import Control.Lens hiding ((<.>))
 import Control.Monad (forM_)
@@ -17,14 +31,157 @@ import qualified Data.DList.DNonEmpty as DLNE
 import Data.Generics.Labels ()
 import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromJust, fromMaybe)
 import Data.Ord (Down (..))
+import Data.Semigroup (Arg (..), Min (..))
 import qualified Data.Text as T
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
 import GitHash
 import Lucid
+import qualified Options.Applicative as Opt
+import Parse (Benchs, decodeBenchs)
 import Plot
+import System.Directory
+import System.FilePath
+import System.IO
 import Types
+import UnliftIO (evaluateDeep, pooledForConcurrently)
 
 type BaselineDescr = T.Text
+
+data SingleReportOpts = SingleReportOpts
+  { input :: !FilePath
+  , output :: !FilePath
+  , sufficesToStrip :: !(Maybe Int)
+  , reportName :: !(Maybe T.Text)
+  , gitInspect :: !Bool
+  , baseline :: !(Maybe FilePath)
+  , baselineDescr :: !(Maybe T.Text)
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+singleReportOptsP :: Opt.Parser SingleReportOpts
+singleReportOptsP = do
+  input <-
+    Opt.strOption
+      $ Opt.long "input"
+      <> Opt.short 'i'
+      <> Opt.metavar "FILE"
+      <> Opt.help "Input CSV file"
+  output <-
+    Opt.strOption
+      $ Opt.long "output"
+      <> Opt.short 'o'
+      <> Opt.metavar "DIR"
+      <> Opt.help "Output directory"
+  sufficesToStrip <-
+    optional
+      $ Opt.option Opt.auto
+      $ Opt.long "strip-suffices"
+      <> Opt.short 's'
+      <> Opt.metavar "NUM"
+      <> Opt.help "Number of prefix to drop."
+  reportName <-
+    optional
+      $ Opt.strOption
+      $ Opt.long "report-name"
+      <> Opt.short 'R'
+      <> Opt.metavar "TITLE"
+      <> Opt.help "Optional Report Name"
+  gitInspect <- Opt.switch $ Opt.long "git" <> Opt.help "Inspects git metadata and includes in the report"
+  baseline <-
+    Opt.optional
+      $ Opt.strOption
+      $ Opt.long "baseline"
+      <> Opt.short 'B'
+      <> Opt.metavar "FILE"
+      <> Opt.help "Optional path to the baseline CSV to compare with"
+  baselineDescr <-
+    Opt.optional
+      $ Opt.strOption
+      $ Opt.long "baseline-desc"
+      <> Opt.metavar "FILE"
+      <> Opt.help "Description for the baseline"
+  pure SingleReportOpts {..}
+
+generateSingleReport :: SingleReportOpts -> IO ()
+generateSingleReport SingleReportOpts {..} = do
+  !trie <-
+    evaluateDeep . pruneSuffices sufficesToStrip =<< decodeBenchs input
+  !mbases <-
+    evaluateDeep
+      . fmap (pruneSuffices sufficesToStrip)
+      =<< mapM decodeBenchs baseline
+  let colorMap = buildColorMap trie
+  createDirectoryIfMissing True output
+  let baseDesc = fromMaybe "Baseline" baselineDescr
+  svgs <- pooledForConcurrently (Map.mapWithKey (,) trie) \(k, bg) -> do
+    let mbase = (baseDesc,) <$> (Map.lookup k =<< mbases)
+    !plots <- evaluate $ mkPlots colorMap k mbase bg
+    !mWinner <-
+      evaluate
+        $ force
+        $ fromJust
+        $ ifoldMap
+          ( \i BenchCase {..} ->
+              Just
+                Winner
+                  { timeWinner = Min $ Arg mean i
+                  , allocWinner = Min $ Arg (fromMaybe 0 alloc) i
+                  , copiedWinner = Min $ Arg (fromMaybe 0 copied) i
+                  }
+          )
+          bg
+    paths <- iforM plots \crit chart -> do
+      let typeStr = case crit of
+            Time -> "time"
+            Alloc -> "alloc"
+            Copied -> "copied"
+          baseName = T.unpack (T.intercalate "-" k) </> typeStr <.> "svg"
+          outPath = output </> baseName
+      createDirectoryIfMissing True $ takeDirectory outPath
+      writeChartOptions outPath chart
+      hPutStrLn stderr $ "Written: " <> outPath
+      pure baseName
+    pure (paths, mWinner)
+
+  mGit <-
+    if gitInspect
+      then
+        either throwIO (pure . Just)
+          =<< either throwIO getGitInfo
+          =<< getGitRoot
+          =<< getCurrentDirectory
+      else pure Nothing
+  let reportHtml = output </> "index.html"
+  print
+    $ L.fold
+      ( L.premap snd
+          $ (,,)
+          <$> L.premap timeWinner winnerCountL
+          <*> L.premap allocWinner winnerCountL
+          <*> L.premap copiedWinner winnerCountL
+      )
+      svgs
+  Lucid.renderToFile reportHtml $ buildReport reportName mGit (baseDesc <$ baseline) svgs
+  hPutStrLn stderr $ "Report Written to: " <> reportHtml
+
+pruneSuffices :: Maybe Int -> Benchs -> Benchs
+pruneSuffices = maybe id \c ->
+  Map.mapKeysMonotonic
+    ( \(V.fromList -> xs) ->
+        V.toList $ V.take (max 0 (V.length xs - c)) xs
+    )
+
+buildColorMap :: (Foldable t) => t (Map.Map T.Text a) -> Map.Map T.Text Colour
+buildColorMap =
+  Map.fromList
+    . flip zip (cycle paletteR)
+    . L.fold
+      ( L.premap Map.keysSet
+          $ L.handles folded L.list
+      )
 
 buildReport :: Maybe T.Text -> Maybe GitInfo -> Maybe BaselineDescr -> Map.Map [T.Text] (Criteria FilePath, Winner Integer) -> Html ()
 buildReport mReportName mGit mbase benchs = doctypehtml_ do

--- a/herbrand.cabal
+++ b/herbrand.cabal
@@ -197,6 +197,7 @@ library herbrand-test-utils
 executable bench-chart
   main-is: Main.hs
   other-modules:
+      Pages
       Parse
       Plot
       Report
@@ -209,7 +210,8 @@ executable bench-chart
       app/bench-chart
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -flate-dmd-anal "-with-rtsopts=--nonmoving-gc -N8" -fproc-alignment=64 -O2 -rtsopts -threaded
   build-depends:
-      aeson
+      Glob
+    , aeson
     , attoparsec
     , base >=4.7 && <5
     , bifunctors
@@ -238,6 +240,8 @@ executable bench-chart
     , lucid2
     , optparse-applicative
     , parallel
+    , path
+    , path-io
     , psqueues
     , random
     , recursion-schemes
@@ -247,6 +251,7 @@ executable bench-chart
     , strict
     , text
     , these
+    , time
     , transformers
     , trie-simple
     , unliftio

--- a/package.yaml
+++ b/package.yaml
@@ -161,6 +161,7 @@ executables:
     - -threaded
     dependencies:
     - herbrand
+    - aeson
     - blaze-markup
     - bytestring
     - cassava
@@ -168,11 +169,15 @@ executables:
     - directory
     - filepath
     - githash
+    - Glob
     - integer-logarithms
     - lucid2
     - optparse-applicative
+    - path
+    - path-io
     - semialign
     - these
+    - time
     - unliftio
 
 tests:


### PR DESCRIPTION
Currently, we have to download artifacts to check generated benchmark result.
This requires extra work to check bench resuts and we have no means to refer to the existing benchmarks after the expiration (retention-days) passed.

- [x] Drop all bench inputs to speed up iteration
- [x] Create pages branch
- [x] Implement pages generation
- [x] Committing and Pushing
- [x] Report to the original Pull Request (if available)
- [x] Revive bench inputs and rebase
- [x] Reset all the `pages` content
- [x] Merge!