### PR TITLE
Workaround for GHC's optimisation bug

### DIFF
--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -3026,4 +3026,4 @@ constraints: abstract-deque ==0.3,
 source-repository-package
   type: git
   location: https://github.com/konn/linear-array-extra.git
-  tag: 15529f65df07d2e966f6a9bd932e1532aadea8e8
+  tag: b96f82103ae5b4e07e9a0f707d031b2a6359c194

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -3026,4 +3026,4 @@ constraints: abstract-deque ==0.3,
 source-repository-package
   type: git
   location: https://github.com/konn/linear-array-extra.git
-  tag: b96f82103ae5b4e07e9a0f707d031b2a6359c194
+  tag: 6d9c0df194b654189446921dc8bb6e1e15c37fb9

--- a/src/Logic/Propositional/Classical/SAT/CDCL.hs
+++ b/src/Logic/Propositional/Classical/SAT/CDCL.hs
@@ -309,7 +309,7 @@ findUIP1 !lit !curCls
       case ml of
         Ur (Just (l', decLvl)) -> S.do
           -- Already Unit clause. Learn it!
-          S.pure $ Just $ Ur $ mkLearntClause decLvl l' curCls
+          S.pure $ Just $ Ur (mkLearntClause decLvl l' curCls)
         Ur Nothing -> S.do
           -- Not a UIP. resolve.
           Ur v <- S.uses valuationL $ LUA.unsafeGet $ fromVarId $ litVar lit
@@ -402,7 +402,7 @@ checkUnitClauseLit ls = S.do
       (ULS 0 St.Nothing 0 (-1))
       ls
   S.pure $ case lcnd of
-    (ULS 1 mx _ pu) | pu >= 0 -> Ur $ (,pu) <$> St.toLazy mx
+    (ULS 1 mx _ pu) | pu >= 0 -> Ur ((,pu) <$> St.toLazy mx)
     _ -> Ur Nothing
 
 foldlLin' :: (Foldable.Foldable t) => b %1 -> (b %1 -> Ur x -> a -> (Ur x, b)) -> x -> t a -> (Ur x, b)

--- a/src/Logic/Propositional/Classical/SAT/CDCL/Types.hs
+++ b/src/Logic/Propositional/Classical/SAT/CDCL/Types.hs
@@ -820,7 +820,7 @@ toCDCLState (CNF cls) lin =
       !watches0 = force $ V.toList $ V.update (V.replicate numVars mempty) (V.fromList $ Map.toList upds)
    in case () of
         _
-          | truth -> lin `lseq` Left (Ur $ Satisfiable ())
+          | truth -> lin `lseq` Left (Ur (Satisfiable ()))
           | contradicting -> lin `lseq` Left (Ur Unsat)
         _ ->
           besides lin (`LUV.fromListL` [0]) PL.& \(steps, lin) ->

--- a/src/Logic/Propositional/Classical/SAT/CDCL/Types.hs
+++ b/src/Logic/Propositional/Classical/SAT/CDCL/Types.hs
@@ -624,6 +624,7 @@ pushClause = \Clause {..} -> S.do
               (fromIntegral lbd >= ema')
   S.pure ()
 
+-- TODO: re-implement decay as the increasing (and uniform decay) on increment factor ala MiniSAT
 decayVarPriosM :: forall s. (Reifies s CDCLOptions) => S.State (VSIDSState s) ()
 {-# INLINE decayVarPriosM #-}
 decayVarPriosM = S.modify \(VSIDSState ls qs spec exc) ->
@@ -632,8 +633,6 @@ decayVarPriosM = S.modify \(VSIDSState ls qs spec exc) ->
     Adaptive {..}
       | exc -> VSIDSState (decayVars highLBDDecay ls) (decayVars highLBDDecay qs) spec exc
       | otherwise -> VSIDSState (decayVars lowLBDDecay ls) (decayVars lowLBDDecay qs) spec exc
-
--- Adaptive {..} -> VSIDSState (decayVars alpha ls) (decayVars alpha qs) spec
 
 decayVars :: Double -> VarQueue -> VarQueue
 {-# INLINE decayVars #-}

--- a/src/Logic/Propositional/Classical/SAT/CDCL/Types.hs
+++ b/src/Logic/Propositional/Classical/SAT/CDCL/Types.hs
@@ -643,7 +643,7 @@ findUnsatVar :: S.State (VSIDSState s) (Ur (Maybe VarId))
 findUnsatVar = S.state \(VSIDSState unsat sat lbdEma exc) ->
   PSQ.minView unsat & \case
     Just (k, p, (), unsat) ->
-      ( Ur $ Just $ fromIntegral k
+      ( Ur (Just $ fromIntegral k)
       , VSIDSState unsat (PSQ.unsafeInsertNew k p () sat) lbdEma exc
       )
     Nothing -> (Ur Nothing, VSIDSState unsat sat lbdEma exc)

--- a/test/Logic/Propositional/Classical/SAT/CDCLSpec.hs
+++ b/test/Logic/Propositional/Classical/SAT/CDCLSpec.hs
@@ -231,7 +231,8 @@ completedModels vars m =
 
 regressionCNFs :: [CNF VarId]
 regressionCNFs =
-  [ CNF [[Negative 0, Negative 1], [Negative 0, Positive 1]]
+  [ CNF []
+  , CNF [[Negative 0, Negative 1], [Negative 0, Positive 1]]
   , CNF [[Negative 1, Negative 0], [Negative 1, Positive 0]]
   , CNF [[Negative 1], [Positive 1]]
   , CNF [[Negative 2], [Positive 2]]


### PR DESCRIPTION
As discovered in [GHC#23973](https://gitlab.haskell.org/ghc/ghc/-/issues/23973), older version of GHC has some bug when eta-reduction is guarded under `Ur`s. This PR tries to avoid that.